### PR TITLE
Add option to disable date

### DIFF
--- a/lib/log-color.js
+++ b/lib/log-color.js
@@ -35,6 +35,7 @@ var Log = exports = module.exports = function Log(setting, stream){
   }
   this.level = level;
   this.color = setting ? Boolean(setting.color) : false;
+  this.date = setting ? Boolean(setting.date) : true;
   this.stream = stream || process.stdout;
   if (this.stream.readable) this.read();
 };
@@ -167,8 +168,8 @@ Log.prototype = {
         levelStr = this.levelColor(levelStr);
       }
       this.stream.write(
-          '[' + now + ']'
-        + ' ' + levelStr
+          (this.date ? '[' + now + '] ' : '')
+        + levelStr
         + ' ' + msg
         + '\n'
       );


### PR DESCRIPTION
Cool, useful library here. Just added in the option to disable the date because it takes up a lot of space on the CLI.

```
var Log = require('log-color');
log = new Log({level: 'debug', color: true, date: false});
```

Calling `log.info('Hello world!')` will now produce:

```
INFO Hello world!
```

Rather than:

```
[Sat May 28 2016 00:26:44 GMT+0100 (GMT Summer Time)] INFO Hello world!
```
